### PR TITLE
Added the ability to edit and save reminders (issue 5)

### DIFF
--- a/app/controllers/reminders/new.js
+++ b/app/controllers/reminders/new.js
@@ -1,12 +1,12 @@
-import Ember from 'ember';
+import Ember from "ember";
 
-export default Ember.Controller.extend({    
+export default Ember.Controller.extend({
   actions: {
     addReminder() {
-      const reminder = this.getProperties('title', 'date', 'notes');
+      const reminder = this.getProperties("title", "date", "notes");
       reminder.date = new Date(reminder.date);
-      this.get('store').createRecord('reminder', reminder).save().then(() => {
-        this.setProperties({ title: '', date: '', notes: '' });
+      this.get("store").createRecord("reminder", reminder).save().then(() => {
+        this.setProperties({ title: "", date: "", notes: "" });
       });
     }
   }

--- a/app/controllers/reminders/new.js
+++ b/app/controllers/reminders/new.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({    
+  actions: {
+    addReminder() {
+      const reminder = this.getProperties('title', 'date', 'notes');
+      reminder.date = new Date(reminder.date);
+      this.get('store').createRecord('reminder', reminder).save().then(() => {
+        this.setProperties({ title: '', date: '', notes: '' });
+      });
+    }
+  }
+});

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Ember from "ember";
 
 export default Ember.Controller.extend({
   store: Ember.inject.service(),
@@ -7,10 +7,10 @@ export default Ember.Controller.extend({
 
   actions: {
     editReminder() {
-      this.set('isEditing', true);
+      this.set("isEditing", true);
     },
     saveReminder() {
-      this.set('isEditing', false);
+      this.set("isEditing", false);
     }
   }
 });

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  store: Ember.inject.service(),
+
+  isEditing: false,
+
+  actions: {
+    editReminder() {
+      this.set('isEditing', true);
+    },
+    saveReminder() {
+      this.set('isEditing', false);
+    }
+  }
+});

--- a/app/router.js
+++ b/app/router.js
@@ -9,6 +9,7 @@ const Router = Ember.Router.extend({
 Router.map(function() {
   this.route('reminders', { path: '/' }, function() {
     this.route('reminder', { path: '/:id' });
+    this.route('new');
   });
 });
 

--- a/app/routes/reminders/new.js
+++ b/app/routes/reminders/new.js
@@ -1,4 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.Route.extend({
-});

--- a/app/routes/reminders/new.js
+++ b/app/routes/reminders/new.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/app/routes/reminders/reminder.js
+++ b/app/routes/reminders/reminder.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model(params) {
+    return this.store.findRecord('reminder', params.id);
+  }
+});

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,4 @@
 <div class="application template">
   <h1>Welcome to Remember</h1>
-  {{outlet}}
 </div>
+{{outlet}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -3,7 +3,7 @@
   <div class="reminders">
     {{#each model as |reminder|}}
       {{#link-to "reminders.reminder" reminder.id class="reminder-title"}}
-      <p class='spec-reminder-item'>
+      <p class="spec-reminder-item">
         {{reminder.title}}
       </p>
       {{/link-to}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,14 +1,19 @@
-<div class="reminders-template">
   <h2>Reminders: </h2>
 
   <div class="reminders">
     {{#each model as |reminder|}}
       {{#link-to "reminders.reminder" reminder.id class="reminder-title"}}
-        <p class="spec-reminder-item">{{reminder.title}}</p>
+      <p class='spec-reminder-item'>
+        {{reminder.title}}
+      </p>
       {{/link-to}}
       <p class="spec-reminder-date">{{reminder.date}}</p>
     {{/each}}
   </div>
 
-  {{outlet}}
-</div>
+    <button class="add-new-reminder">
+      {{#link-to "reminders.new" class="spec-add-new-reminder"}}
+        Add new reminder
+      {{/link-to}}
+    </button>
+{{outlet}}

--- a/app/templates/reminders/new.hbs
+++ b/app/templates/reminders/new.hbs
@@ -1,0 +1,17 @@
+<h2>New Reminder</h2>
+<form class="add-reminder-form" {{action "addReminder" on="submit"}}>
+ <label>
+   Title
+   {{input class="spec-input-title" value=title}}
+ </label>
+ <label>
+   Date
+   {{input type="date" class="spec-input-date" value=date}}
+ </label>
+ <label>
+   Notes
+   {{textarea class="spec-input-notes" value=notes}}
+ </label>
+ <button class="submit-button">Submit</button>
+</form>
+{{outlet}}

--- a/app/templates/reminders/new.hbs
+++ b/app/templates/reminders/new.hbs
@@ -2,7 +2,7 @@
 <form class="add-reminder-form" {{action "addReminder" on="submit"}}>
  <label>
    Title
-   {{input class="spec-input-title" value=title}}
+   {{input type="text" class="spec-input-title" value=title}}
  </label>
  <label>
    Date
@@ -10,7 +10,7 @@
  </label>
  <label>
    Notes
-   {{textarea class="spec-input-notes" value=notes}}
+   {{textarea type="text" class="spec-input-notes" value=notes}}
  </label>
  <button class="submit-button">Submit</button>
 </form>

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,4 +1,26 @@
 <div class="spec-reminder-title">
+  {{#if isEditing}}
+  {{input class="edit-title" value=model.title}}
+  {{input class="edit-date" value=model.date}}
+  {{input class="edit-notes" value=model.notes}}
+  {{else}}
   <h1>{{model.title}}</h1>
+  <h1>{{model.date}}</h1>
+  <h1>{{model.notes}}</h1>
+  {{/if}}
 </div>
+<section class="save-edit-buttons">
+  <button
+    class="edit-button"
+    {{action "editReminder" on="click"}}
+  >
+    Edit
+  </button>
+  <button
+    class="save-button"
+    {{action "saveReminder" on="click"}}
+  >
+  Save
+</button>
+</section>
 {{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,26 +1,24 @@
 <div class="spec-reminder-title">
   {{#if isEditing}}
-  {{input class="edit-title" value=model.title}}
-  {{input class="edit-date" value=model.date}}
-  {{input class="edit-notes" value=model.notes}}
+    {{input type="text" class="edit-title" value=model.title}}
+    {{input type="date" class="edit-date" value=model.date}}
+    {{input type="text" class="edit-notes" value=model.notes}}
+    <button
+      class="save-button"
+      {{action "saveReminder" on="click"}}
+      >
+      Save
+    </button>
   {{else}}
-  <h1>{{model.title}}</h1>
-  <h1>{{model.date}}</h1>
-  <h1>{{model.notes}}</h1>
+    <h1>{{model.title}}</h1>
+    <h1>{{model.date}}</h1>
+    <h1>{{model.notes}}</h1>
+    <button
+      class="edit-button"
+      {{action "editReminder" on="click"}}
+    >
+      Edit
+    </button>
   {{/if}}
 </div>
-<section class="save-edit-buttons">
-  <button
-    class="edit-button"
-    {{action "editReminder" on="click"}}
-  >
-    Edit
-  </button>
-  <button
-    class="save-button"
-    {{action "saveReminder" on="click"}}
-  >
-  Save
-</button>
-</section>
 {{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,4 +1,4 @@
 <div class="spec-reminder-title">
   <h1>{{model.title}}</h1>
-  {{outlet}}
 </div>
+{{outlet}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -41,13 +41,14 @@ test('creating a form to make a new reminder', function(assert) {
 
   andThen(function() {
     assert.equal(currentURL(), '/new');
-    assert.equal(Ember.$('.add-reminder-form').length,1)
+    assert.equal(Ember.$('.add-reminder-form').length,1);
   });
 });
 
 test('creating an new reminder', function(assert) {
   visit('/new');
 
+<<<<<<< HEAD
   fillIn('.spec-input-title', 'Call Mike')
   fillIn('.spec-input-date', '2016-11-11')
   fillIn('.spec-input-notes', 'Birthday')
@@ -65,5 +66,18 @@ test('creating an new reminder', function(assert) {
   andThen(function() {
     assert.equal(Ember.$('.spec-reminder-item:last').text().trim(), 'Call Mike')
     assert.equal(Ember.$('.spec-reminder-date:last').text().trim(), 'Thu Nov 10 2016 17:00:00 GMT-0700 (MST)')
+  });
+});
+
+test('editing a reminder', function(assert) {
+  visit('/');
+  click('.spec-reminder-item:first');
+  click('.edit-button');
+  fillIn('.edit-title', 'What up Mike?!');
+  click('.save-button');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/1');
+    assert.equal(Ember.$('.spec-reminder-item:last').text().trim(), 'What up Mike?!');
   });
 });

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -48,7 +48,6 @@ test('creating a form to make a new reminder', function(assert) {
 test('creating an new reminder', function(assert) {
   visit('/new');
 
-<<<<<<< HEAD
   fillIn('.spec-input-title', 'Call Mike')
   fillIn('.spec-input-date', '2016-11-11')
   fillIn('.spec-input-notes', 'Birthday')

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -34,3 +34,36 @@ test('clicking on an individual item', function(assert) {
     assert.equal(Ember.$('.spec-reminder-item:first').text().trim(), Ember.$('.spec-reminder-title').text().trim());
   });
 });
+
+test('creating a form to make a new reminder', function(assert) {
+  visit('/');
+  click('.spec-add-new-reminder');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/new');
+    assert.equal(Ember.$('.add-reminder-form').length,1)
+  });
+});
+
+test('creating an new reminder', function(assert) {
+  visit('/new');
+
+  fillIn('.spec-input-title', 'Call Mike')
+  fillIn('.spec-input-date', '2016-11-11')
+  fillIn('.spec-input-notes', 'Birthday')
+
+
+  andThen(function() {
+    assert.equal(currentURL(), '/new')
+    assert.equal(Ember.$('.spec-input-title').val(), 'Call Mike')
+    assert.equal(Ember.$('.spec-input-date').val(), '2016-11-11')
+    assert.equal(Ember.$('.spec-input-notes').val(), 'Birthday')
+  });
+
+  click('.submit-button')
+
+  andThen(function() {
+    assert.equal(Ember.$('.spec-reminder-item:last').text().trim(), 'Call Mike')
+    assert.equal(Ember.$('.spec-reminder-date:last').text().trim(), 'Thu Nov 10 2016 17:00:00 GMT-0700 (MST)')
+  });
+});

--- a/tests/integration/components/post-reminder-test.js
+++ b/tests/integration/components/post-reminder-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('post-reminder', 'Integration | Component | post reminder', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{post-reminder}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#post-reminder}}
+      template block text
+    {{/post-reminder}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/unit/controllers/reminders/edit-test.js
+++ b/tests/unit/controllers/reminders/edit-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:reminders/edit', 'Unit | Controller | reminders/edit', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/tests/unit/controllers/reminders/new-test.js
+++ b/tests/unit/controllers/reminders/new-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:reminders/new', 'Unit | Controller | reminders/new', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/tests/unit/routes/edit-test.js
+++ b/tests/unit/routes/edit-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:edit', 'Unit | Route | edit', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/tests/unit/routes/new-test.js
+++ b/tests/unit/routes/new-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:new', 'Unit | Route | new', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
Purpose

Add the ability to edit and save a reminder

Approach

Allow the editing of reminders through "isEditing" property

Learning

Consulted the ember docs and discussed with classmates

https://guides.emberjs.com/v2.0.0/models/creating-updating-and-deleting-records/

Blog Posts

Open Questions and Pre-Merge TODOs

 Use Github checklists. When solved, check the box and explain the answer.
Test coverage

Tested to verify that the reminder was updated with the value of the input field after clicking "save"