### PR TITLE
Added a visual cue for unsaved changes (issue 7)

### DIFF
--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -4,23 +4,18 @@ export default Ember.Controller.extend({
   store: Ember.inject.service(),
 
   isEditing: false,
-  dirtyAttributesPresent: false,
 
   actions: {
     editReminder() {
       this.set("isEditing", true);
     },
     saveReminder() {
-      this.set("isEditing", false);
+      this.get('model').save().then( () => {
+        this.set("isEditing", false);        
+      });
     },
     revertReminder() {
       this.get('model').rollbackAttributes();
-      this.set("dirtyAttributesPresent", false);
-    },
-    checkDirtyAttributes() {
-      const record = this.get('model');
-      record.get('hasDirtyAttributes');
-      this.set("dirtyAttributesPresent", true);
     }
   }
 });

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  store: Ember.inject.service(),
+
+  isEditing: false,
+
+  actions: {
+    editReminder() {
+      this.set('isEditing', true);
+    },
+    saveReminder() {
+      this.set('isEditing', false);
+    }
+  }
+});

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -23,3 +23,7 @@
   font-size: 20px;
   font-weight: bold;
 }
+
+.unsaved {
+  color: red;
+}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -7,7 +7,10 @@
         {{reminder.title}}
       </p>
       {{/link-to}}
-        <p class="spec-reminder-date">{{reminder.date}}</p>
+      {{#if reminder.hasDirtyAttributes}}
+        <h1 class="unsaved">Please Save</h1>
+      {{/if}}
+      <p class="spec-reminder-date">{{reminder.date}}</p>
     {{/each}}
   </div>
 

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,4 +1,26 @@
 <div class="spec-reminder-title">
+  {{#if isEditing}}
+  {{input class="edit-title" value=model.title}}
+  {{input class="edit-date" value=model.date}}
+  {{input class="edit-notes" value=model.notes}}
+  {{else}}
   <h1>{{model.title}}</h1>
+  <h1>{{model.date}}</h1>
+  <h1>{{model.notes}}</h1>
+  {{/if}}
 </div>
+<section class="save-edit-buttons">
+  <button
+    class="edit-button"
+    {{action "editReminder" on="click"}}
+  >
+    Edit
+  </button>
+  <button
+    class="save-button"
+    {{action "saveReminder" on="click"}}
+  >
+  Save
+</button>
+</section>
 {{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -3,7 +3,7 @@
     {{input type="text" class="edit-title" value=model.title key-press="checkDirtyAttributes"}}
     {{input type="date" class="edit-date" value=model.date key-press="checkDirtyAttributes"}}
     {{input type="text" class="edit-notes" value=model.notes key-press="checkDirtyAttributes"}}
-    <button class="revert-button" hidden={{ unless model.hasDirtyAttributes "true"}} {{action "revertReminder" on="click"}} 
+    <button class="revert-button" hidden={{ unless model.hasDirtyAttributes "true"}} {{action "revertReminder" on="click"}}
     >Revert</button>
     <button
       class="save-button"

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -3,10 +3,8 @@
     {{input type="text" class="edit-title" value=model.title key-press="checkDirtyAttributes"}}
     {{input type="date" class="edit-date" value=model.date key-press="checkDirtyAttributes"}}
     {{input type="text" class="edit-notes" value=model.notes key-press="checkDirtyAttributes"}}
-  {{#if dirtyAttributesPresent}}
-    <button class="revert-button" {{action "revertReminder" on="click"}}
+    <button class="revert-button" hidden={{ unless model.hasDirtyAttributes "true"}} {{action "revertReminder" on="click"}} 
     >Revert</button>
-  {{/if}}
     <button
       class="save-button"
       {{action "saveReminder" on="click"}}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -2,6 +2,6 @@ export default function() {
   this.get('/reminders');
   this.post('/reminders');
   this.get('/reminders/:id');
-  this.put('/reminders/:id');
+  this.patch('/reminders/:id');
   this.del('/reminders/:id');
 }

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -92,16 +92,13 @@ test('reverting a reminder', function(assert) {
     assert.equal(Ember.$('.spec-reminder-item:first').text().trim(), 'What up Mike?!');
   });
 
-  click('.spec-reminder-item:last');
-  click('.spec-reminder-item:first');
+  click('.save-button');
+  click('.edit-button');
+  fillIn('.edit-title', 'Are you there Ben?!');
   click('.revert-button');
 
   andThen(function() {
     assert.equal(currentURL(), '/1');
-    assert.equal(Ember.$('.spec-reminder-item:first').text().trim(), Ember.$('.spec-reminder-title').text().trim());
+    assert.equal(Ember.$('.spec-reminder-item:first').text().trim(), 'What up Mike?!');
   });
-
-
-
-
 });

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -102,3 +102,14 @@ test('reverting a reminder', function(assert) {
     assert.equal(Ember.$('.spec-reminder-item:first').text().trim(), 'What up Mike?!');
   });
 });
+
+test('visual indication of unsaved reminders', function(assert) {
+  visit('/');
+  click('.spec-reminder-item:first');
+  click('.edit-button');
+  fillIn('.edit-title', 'What up Mike?!');
+  andThen(function() {
+    assert.equal(currentURL(), '/1');
+    assert.equal(Ember.$('.unsaved').length, 1);
+  });
+});

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -41,20 +41,32 @@ test('creating an area to make a new reminder', function(assert) {
 
   andThen(function() {
     assert.equal(currentURL(), '/new');
-    assert.equal(Ember.$('.add-reminder-form').length,1)
+    assert.equal(Ember.$('.add-reminder-form').length,1);
   });
 });
 
 test('creating an new reminder', function(assert) {
   visit('/new');
 
-  fillIn('.spec-input-title.ember-view.ember-text-field', 'Call Mike')
-  fillIn('.spec-input-date', '11/11/2016')
-  fillIn('.spec-input-notes', 'Party')
-
+  fillIn('.spec-input-title.ember-view.ember-text-field', 'Call Mike');
+  fillIn('.spec-input-date', '11/11/2016');
+  fillIn('.spec-input-notes', 'Party');
 
   andThen(function() {
     assert.equal(currentURL(), '/new');
-    assert.equal(Ember.$('.spec-input-title').value, 'Call Mike');
+    assert.equal(Ember.$('.spec-input-title').val(), 'Call Mike');
+  });
+});
+
+test('editing a reminder', function(assert) {
+  visit('/');
+  click('.spec-reminder-item:first');
+  click('.edit-button');
+  fillIn('.edit-title', 'What up Mike?!');
+  click('.save-button');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/1');
+    assert.equal(Ember.$('.spec-reminder-item:last').text().trim(), 'What up Mike?!');
   });
 });

--- a/tests/unit/controllers/reminders/edit-test.js
+++ b/tests/unit/controllers/reminders/edit-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:reminders/edit', 'Unit | Controller | reminders/edit', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/tests/unit/routes/edit-test.js
+++ b/tests/unit/routes/edit-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:edit', 'Unit | Route | edit', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
## Purpose

To add a visual cue to indicate that changes to reminders have not been saved

## Approach

Added text reminders to each item that has dirty attributes

### Learning

Same as our revert issue, used ember docs for "hasDirtyAttributes"

### Test coverage 

Tested to see if the class of "unsaved" has a length of 1 after changes have been made and not saved